### PR TITLE
Fix import on case-sensitive file system 

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import CartScrollBar from './CartScrollBar';
-import Counter from './counter';
+import Counter from './Counter';
 import EmptyCart from '../empty-states/EmptyCart';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 

--- a/components/Product.js
+++ b/components/Product.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import Counter from './counter';
+import Counter from './Counter';
 
 class Product extends Component{
 	constructor(props){


### PR DESCRIPTION
Chromium on Ubuntu could not import the `Counter` class as it was looking for a lowercased file which did not exist. This fixes that by respecting case-sensitive file systems.